### PR TITLE
support esbuild watch

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -1,11 +1,10 @@
-import { build } from "esbuild";
+import * as esbuild from "esbuild";
 import { rmSync } from "fs";
 
 // Remove the previous build directory
 rmSync("./.local/express/dist", { recursive: true, force: true });
 
-// Run esbuild with the specified options
-build({
+const config = {
   entryPoints: ["src/server/express/server.ts"],
   bundle: true,
   sourcemap: true,
@@ -15,4 +14,15 @@ build({
   external: [],
   outfile: "./.local/express/dist/api.js",
   tsconfig: "./tsconfig.json",
-}).catch(() => process.exit(1));
+};
+if (process.argv.includes("--watch")) {
+  async function watch() {
+    let ctx = await esbuild.context(config);
+    await ctx.watch();
+    console.log("Watching...");
+  }
+  watch(); // Must not have an `await` for watch to work
+} else {
+  // Run esbuild with the specified options
+  esbuild.build(config).catch(() => process.exit(1));
+}


### PR DESCRIPTION
Support optional --watch argument in esbuild.mjs script so that the package script api:build:watch will actually watch and rebuild the server source code. Currently in the main branch, running `npm run dev` will run `api:build:watch`, but the `--watch` argument is a CLI argument, and is not passed to the esbuild.mjs script. With this fix, `api:build` and `api:build:watch` will run the same esbuild.mjs script with the different expected behavior.

Bug repro steps: 
1. `npm run dev`
2. Edit one of the server files.

Expected: 
- esbuild will watch server changes, rebuild dist, and reload the server.

Actual: 
- esbuild does not respond to any server changes.

Bug fix:
- `npm run api:build` will rebuild server without watching.
- `npm run dev` and `npm run api:build:watch` will rebuild server and also watch for changes.